### PR TITLE
Fix ball physics when texture is changed

### DIFF
--- a/scripts/components/balls/basic_ball.gd
+++ b/scripts/components/balls/basic_ball.gd
@@ -40,19 +40,19 @@ var _hang_timer: SceneTreeTimer
 
 const DEFAULT_BALL_SIZE: Vector2 = Vector2(128, 128)
 
-func get_abs_radius_size() -> float:
+## Return the radius for the circle collision shape.  
+## If [member texture] is provided, obtain the radius from the texture size.  
+func get_shape_radius() -> float:
 	if not is_node_ready() or not is_instance_valid(texture):
 		return _INITIAL_RADIUS
 	var texture_size: Vector2 = texture.get_size()
-	if texture_size.x < texture_size.y:
-		return texture_size.x / 2
-	return texture_size.y / 2
+	return min(texture_size.x, texture_size.y) / 2
 
 func _set_size(new_size: float):
 	size = new_size
 	if not is_node_ready():
 		return
-	_shape.shape.radius = get_abs_radius_size() * size
+	_shape.shape.radius = get_shape_radius() * size
 	_sprite.scale = Vector2(size, size)
 
 func _set_texture(new_texture: Texture2D):

--- a/scripts/components/balls/basic_ball.gd
+++ b/scripts/components/balls/basic_ball.gd
@@ -38,19 +38,27 @@ var _hang_timer: SceneTreeTimer
 @onready var _sprite: Sprite2D = %Sprite2D
 @onready var _initial_texture: Texture2D = %Sprite2D.texture
 
+const DEFAULT_BALL_SIZE: Vector2 = Vector2(128, 128)
+
+func get_abs_radius_size() -> float:
+	if not is_node_ready() or not is_instance_valid(texture):
+		return _INITIAL_RADIUS
+	var texture_size: Vector2 = texture.get_size()
+	if texture_size.x < texture_size.y:
+		return texture_size.x / 2
+	return texture_size.y / 2
 
 func _set_size(new_size: float):
 	size = new_size
 	if not is_node_ready():
-		await ready
-	_shape.shape.radius = _INITIAL_RADIUS * size
+		return
+	_shape.shape.radius = get_abs_radius_size() * size
 	_sprite.scale = Vector2(size, size)
 
-
 func _set_texture(new_texture: Texture2D):
-	if not is_node_ready():
-		await ready
 	texture = new_texture
+	if not is_node_ready():
+		return
 	if texture != null:
 		_sprite.texture = texture
 	else:


### PR DESCRIPTION
the ball radius is currently fixed to the size of the default texture; this changes it such that it's linked to the size of the *current* texture