### PR TITLE
Fix left paddle control in web export

### DIFF
--- a/export_presets.cfg
+++ b/export_presets.cfg
@@ -2,7 +2,7 @@
 
 name="Web"
 platform="Web"
-runnable=false
+runnable=true
 advanced_options=false
 dedicated_server=false
 custom_features=""
@@ -10,8 +10,10 @@ export_filter="all_resources"
 include_filter=""
 exclude_filter=""
 export_path=""
+patches=PackedStringArray()
 encryption_include_filters=""
 encryption_exclude_filters=""
+seed=0
 encrypt_pck=false
 encrypt_directory=false
 script_export_mode=2

--- a/scripts/components/paddles/basic_paddle.gd
+++ b/scripts/components/paddles/basic_paddle.gd
@@ -25,29 +25,33 @@ extends CharacterBody2D
 
 
 func _set_player(new_player: Global.Player) -> void:
-	if not is_node_ready():
-		await ready
 	player = new_player
+
+	if not is_node_ready():
+		return
+
 	_sprite.flip_h = player == Global.Player.RIGHT
-	notify_property_list_changed()
 
 
 func _set_texture(new_texture: Texture2D) -> void:
-	if not is_node_ready():
-		await ready
 	texture = new_texture
+
+	if not is_node_ready():
+		return
+
 	if texture != null:
 		_sprite.texture = texture
 	else:
 		_sprite.texture = _initial_texture
-	notify_property_list_changed()
 
 
 func _set_tint(new_tint: Color) -> void:
 	tint = new_tint
-	if is_node_ready():
-		_sprite.modulate = tint
-	notify_property_list_changed()
+
+	if not is_node_ready():
+		return
+
+	_sprite.modulate = tint
 
 
 func _ready() -> void:

--- a/scripts/components/paddles/basic_paddle.gd
+++ b/scripts/components/paddles/basic_paddle.gd
@@ -24,7 +24,7 @@ extends CharacterBody2D
 @onready var _initial_texture: Texture2D = %Sprite2D.texture
 
 
-func _set_player(new_player: Global.Player):
+func _set_player(new_player: Global.Player) -> void:
 	if not is_node_ready():
 		await ready
 	player = new_player
@@ -32,7 +32,7 @@ func _set_player(new_player: Global.Player):
 	notify_property_list_changed()
 
 
-func _set_texture(new_texture: Texture2D):
+func _set_texture(new_texture: Texture2D) -> void:
 	if not is_node_ready():
 		await ready
 	texture = new_texture
@@ -43,14 +43,14 @@ func _set_texture(new_texture: Texture2D):
 	notify_property_list_changed()
 
 
-func _set_tint(new_tint: Color):
+func _set_tint(new_tint: Color) -> void:
 	tint = new_tint
 	if is_node_ready():
 		_sprite.modulate = tint
 	notify_property_list_changed()
 
 
-func _ready():
+func _ready() -> void:
 	if Engine.is_editor_hint():
 		set_process(false)
 		set_physics_process(false)
@@ -59,7 +59,7 @@ func _ready():
 	_set_tint(tint)
 
 
-func _physics_process(_delta):
+func _physics_process(_delta: float) -> void:
 	var direction: Vector2
 	if player == Global.Player.RIGHT:
 		direction = Input.get_vector("ui_left", "ui_right", "ui_up", "ui_down")
@@ -85,5 +85,5 @@ func _physics_process(_delta):
 	move_and_slide()
 
 
-func on_ball_hit():
+func on_ball_hit() -> void:
 	DampedOscillator.animate(%Sprite2D, "scale", 600.0, 20.0, -15.0, 0.75)


### PR DESCRIPTION
The actual fix is the last commit:

> **basic_paddle: Don't await ready in setters**
> 
> This is unnecessary because we reapply the properties in _ready() by invoking the setters again.
> 
> It's also actively harmful: in web exports, it causes the assigment of non-default values of the `player` property to be lost, meaning that both paddles in the main scene are controlled by the arrow keys (Player.RIGHT). I have to say that I don't fully understand why it happens, but this change does fix it!

As a precursor to this change, add some type hints, and make the web export preset runnable, which makes it easier to test the web export locally.

Fixes #11